### PR TITLE
Added an auto-intro command

### DIFF
--- a/twitch_bot.py
+++ b/twitch_bot.py
@@ -149,6 +149,8 @@ def autoOptIn(user,data):
     if user not in db.getUsers():
         twitch_bot_utils.printer("Auto Opting %s in!" % user)
         opt(user,True)
+        irc.msg("Check out this 1 minute video that explains my stream! https://www.youtube.com/watch?v=q0q8SML6d_I")
+
 
 def scare_lock(status):
     global scaring


### PR DESCRIPTION
I just copied and pasted the command that happens when "!intro" is typed into the autoOptIn function, so any time someone gets auto-opted-in (presumably this is whenever they say something in chat for the first time; I didn't actually check) the intro message will play.